### PR TITLE
Changed Install/Cancel button texts to properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Then you can use the element `<pwa-install></pwa-install>` anywhere in your temp
 | `manifestpath`      | `manifestpath`      | path to your web manifest                         | `string`  | `manifest.json` |
 | `featuresheader`    | `featuresheader`    | Controls the text of the features header          | `string`  | `Key Features`  |
 | `descriptionheader` | `descriptionheader` | Controls the text of the description header       | `string`  | `Description`   |
+| `installbuttontext` | `installbuttontext` | Controls the text of the install button           | `string`  | `Install`       |
+| `cancelbuttontext`  | `cancelbuttontext`  | Controls the text of the cancel button            | `string`  | `Cancel`        |
+| `iosinstallinfotext`| `iosinstallinfotext`| Controls the iOS installing info text             | `string`  | `Tap the share button and then 'Add to Homescreen'`   |
 
 ### Methods
 

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -19,6 +19,9 @@ export class pwainstall extends LitElement {
   @property() explainer: string = "This app can be installed on your PC or mobile device.  This will allow this web app to look and behave like any other installed up.  You will find it in your app lists and be able to pin it to your home screen, start menus or task bars.  This installed web app will also be able to safely interact with other apps and your operating system. "
   @property() featuresheader: string = "Key Features";
   @property() descriptionheader: string = "Description";
+  @property() installbuttontext: string = "Install";
+  @property() cancelbuttontext: string = "Cancel";
+  @property() iosinstallinfotext: string = "Tap the share button and then 'Add to Homescreen'";
 
   static get styles() {
     return css`
@@ -522,7 +525,7 @@ export class pwainstall extends LitElement {
     return html`
       ${this.shouldShowInstall() ? html`<button id="openButton" @click="${() => this.openPrompt()}">
         <slot>
-          Install
+          ${this.installbuttontext}
         </slot>
       </button>` : null}
 
@@ -593,9 +596,9 @@ export class pwainstall extends LitElement {
         </div>
 
         ${!this.isIOS ? html`<div id="buttonsContainer">
-          ${this.deferredprompt ? html`<button id="installButton" @click="${() => this.install()}">Install ${this.manifestdata.short_name}</button>` : html`<button @click="${() => this.cancel()}" id="installButton">Close</button>`}
+          ${this.deferredprompt ? html`<button id="installButton" @click="${() => this.install()}">${this.installbuttontext} ${this.manifestdata.short_name}</button>` : html`<button @click="${() => this.cancel()}" id="installButton">${this.cancelbuttontext}</button>`}
         </div>
-          </div>` : html`<p id="iosText">Tap the share button and then 'Add to Homescreen'</p>`}
+          </div>` : html`<p id="iosText">${this.iosinstallinfotext}</p>`}
         `
         : null
       }

--- a/www/index.html
+++ b/www/index.html
@@ -24,7 +24,11 @@
 
   <pwa-install id="lesser" manifestpath="manifest-lesser.json"></pwa-install>
 
-  <pwa-install id="ownContent" featuresheader="My own features header" descriptionheader="My description"></pwa-install>
+  <pwa-install id="ownContent" featuresheader="My own features header" 
+    descriptionheader="My description" 
+    iosinstallinfotext="Yo, dude! Tap the share button and then 'Add to Homescreen'"
+    installbuttontext="Click here to install"
+    cancelbuttontext="I'll do it later!"></pwa-install>
 
   <pwa-install id="invalidMani" manifestpath="manifest-invalid.json"></pwa-install>
 


### PR DESCRIPTION
@jgw96 here is my PR. This is related to https://github.com/pwa-builder/pwa-install/issues/25

Also the iOS info text is now a property so it can be localised as well.
And readme is updated.  You may want to change the descriptions.