### PR TITLE
add focus styles to interactable elements

### DIFF
--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -29,6 +29,7 @@ export class pwainstall extends LitElement {
   static get styles() {
     return css`
      :host {
+       --install-focus-color: #919c9c;
        --install-button-color: linear-gradient(90deg, #1FC2C8 0%, #9337D8 169.8%);
        --modal-z-index: 9999;
        --background-z-index: 9998;
@@ -188,6 +189,13 @@ export class pwainstall extends LitElement {
       align-self: self-end;
      }
 
+
+     #closeButton:focus,
+     #installButton:focus,
+     #installCancelButton:focus {
+      box-shadow: 0 0 0 3px var(--install-focus-color);
+     }
+
      #contentContainer {
        margin-left: 40px;
        margin-right: 40px;
@@ -247,6 +255,7 @@ export class pwainstall extends LitElement {
       transition: background-color 0.2s;
      }
 
+     #screenshotsContainer button:focus,
      #screenshotsContainer button:hover {
        background-color: #bbbbbb;
      }


### PR DESCRIPTION
Fixes #

Partially address #104. This pr does nothing to solve focus management, it just adds some focus styles. The gray I picked for the focus color fits with the default UI and is customizable with `--input-focus-color`.

## PR Type

Bugfix

## Describe the current behavior?

It show no focus styling.


## Describe the new behavior?

It shows focus styling


## PR Checklist

- [ ] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

