### PR TITLE
Fix long features list text clipping

### DIFF
--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -206,7 +206,7 @@ export class pwainstall extends LitElement {
 
      #featuresScreenDiv {
       display: flex;
-      justify-content: space-between;
+      justify-content: space-around;
       align-items: center;
       margin-right: 20px;
      }

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -207,6 +207,7 @@ export class pwainstall extends LitElement {
      #featuresScreenDiv {
       display: flex;
       justify-content: space-between;
+      align-items: center;
       margin-right: 20px;
      }
 
@@ -219,7 +220,6 @@ export class pwainstall extends LitElement {
      }
 
      #keyFeatures {
-      max-height: 220px;
       overflow: hidden;
      }
 
@@ -237,6 +237,7 @@ export class pwainstall extends LitElement {
      }
 
      #screenshotsContainer {
+       max-height: 220px;
        display: flex;
      }
 


### PR DESCRIPTION
## PR Type

Bugfix

## Describe the current behavior?

When there the features are long the text gets clipped

<img width="978" alt="Screen Shot 2020-01-05 at 8 16 12 AM" src="https://user-images.githubusercontent.com/1192452/71782896-3ccdb180-2f94-11ea-8a7b-37b653809fa3.png">

## Describe the new behavior?

The text is not clipped. max-height moved to screen shot container.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.
