### PR TITLE
allow for white-space in description

### DIFF
--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -348,6 +348,10 @@ export class pwainstall extends LitElement {
       bottom: 0;
     }
 
+    #manifest-description {
+      white-space: pre-wrap;
+    }
+
     @media(max-height: 780px) {
       #buttonsContainer {
         bottom: -1em;
@@ -758,7 +762,7 @@ export class pwainstall extends LitElement {
 
           <div>
             <h3>${this.descriptionheader}</h3>
-            <p>${this.manifestdata.description}</p>
+            <p id="manifest-description">${this.manifestdata.description}</p>
           </div>
         </div>
 


### PR DESCRIPTION
## PR Type

Feature

## Describe the current behavior?

Putting `\n` in the description produces html without breaks.

## Describe the new behavior?

Description area wii now respect newlines.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information

While this may not be a part of any spec it's useful to be able to have newlines in the description. If newlines are not supported on a platform that respect newlines it shouldn't break the ui. 

I understand if this PR is not accepted.
