### PR TITLE
fix close button placement on certain screen sizes

### DIFF
--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -295,7 +295,8 @@ export class pwainstall extends LitElement {
      }
 
      #desc {
-      width: 40em;
+      width: 100%;
+      max-width: 40em;
       font-size: 14px;
       color: #7E7E7E;
       text-overflow: ellipsis;
@@ -706,8 +707,8 @@ export class pwainstall extends LitElement {
               <h1>${this.manifestdata.name}</h1>
 
               <p id="desc">
-              ${this.explainer}
-            </p>
+                ${this.explainer}
+              </p>
             </div>
           </div>
 


### PR DESCRIPTION
## PR Type

Bugfix

## Describe the current behavior?

ON certain screen sizes the close button would overflow the modal

<img width="1449" alt="Screen Shot 2020-01-05 at 8 56 05 AM" src="https://user-images.githubusercontent.com/1192452/71783342-64277d00-2f9a-11ea-9462-82e68351d85d.png">


## Describe the new behavior?

No overflow

<img width="1469" alt="Screen Shot 2020-01-05 at 9 04 54 AM" src="https://user-images.githubusercontent.com/1192452/71783354-79041080-2f9a-11ea-99b1-65525e413f29.png">

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

