### PR TITLE
center title on mobile

### DIFF
--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -394,6 +394,14 @@ export class pwainstall extends LitElement {
       }
 
       @media (max-width: 962px) {
+        #headerContainer h1  {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
+
+        #logoContainer {
+          align-items: center
+        }
 
         #desc {
           display: none;


### PR DESCRIPTION
## PR Type

Bugfix Title was not centered on mobile. Looked odd

## Describe the current behavior?

<img width="402" alt="Screen Shot 2020-01-05 at 8 33 35 PM" src="https://user-images.githubusercontent.com/1192452/71795375-b7311c80-2ffa-11ea-8274-12a8ea4e8f2b.png">

## Describe the new behavior?

<img width="383" alt="Screen Shot 2020-01-05 at 8 33 26 PM" src="https://user-images.githubusercontent.com/1192452/71795383-c9ab5600-2ffa-11ea-9a1e-109f83ad9ff3.png">


## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
