### PR TITLE
fix overflow scroll and cut off text

### DIFF
--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -39,13 +39,25 @@ export class pwainstall extends LitElement {
        outline: none;
      }
 
+     #installModalWrapper {
+      height: 100vh;
+      width: 100vw;
+      overflow: auto;
+      position: fixed;
+      bottom: 0;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: var(--modal-z-index);
+     }
+
+     #descriptionWrapper {
+       margin-bottom: 3em;
+     }
+
      #installModal {
       background: var(--modal-background-color);
-      position: fixed;
-      bottom: 3em;
-      top: 3em;
-      left: 12em;
-      right: 12em;
+      margin: 3em 12em;
       font-family: sans-serif;
       box-shadow: 0px 25px 26px rgba(32, 36, 50, 0.25), 0px 5px 9px rgba(51, 58, 83, 0.53);
       border-radius: 10px;
@@ -357,32 +369,30 @@ export class pwainstall extends LitElement {
 
       @media(min-width: 1445px) {
         #installModal {
-          left: 22em;
-          right: 22em;
+          margin-left: 22em;
+          margin-right: 22em;
         }
       }
 
       @media(min-width: 1800px) {
         #installModal {
-          left: 26em;
-          right: 26em;
+          margin-left: 26em;
+          margin-right: 26em;
         }
       }
 
       @media(min-width: 2000px) {
         #installModal {
-          left: 38em;
-          right: 38em;
+          margin-left: 38em;
+          margin-right: 38em;
         }
       }
 
       @media(max-width: 1220px) {
         #installModal {
-          bottom: 0em;
-          top: 0em;
-          left: 0em;
-          right: 0em;
+          margin: 0;
           border-radius: 0px;
+          min-height: 100%;
 
           animation-name: mobile;
           animation-duration: 250ms;
@@ -697,6 +707,7 @@ export class pwainstall extends LitElement {
       ${
       this.openmodal ?
         html`
+          <div id="installModalWrapper">
           <div id="installModal">
           <div id="headerContainer">
           <div id="logoContainer">
@@ -733,6 +744,7 @@ export class pwainstall extends LitElement {
             }) : null
             }
             </ul>
+          </div>
           </div>` : null}
 
           ${this.manifestdata.screenshots ?
@@ -756,7 +768,7 @@ export class pwainstall extends LitElement {
             ` : null}
           </div>
 
-          <div>
+          <div id="descriptionWrapper">
             <h3>${this.descriptionheader}</h3>
             <p>${this.manifestdata.description}</p>
           </div>


### PR DESCRIPTION
Fixes #112 

## PR Type

Bugfix

## Describe the current behavior?

<img width="1364" alt="Screen Shot 2020-01-05 at 8 30 31 PM" src="https://user-images.githubusercontent.com/1192452/71795412-ed6e9c00-2ffa-11ea-8630-bf96b0e33e2e.png">

## Describe the new behavior?

The modal now has a dynamic height and is scrollable.

<img width="1050" alt="Screen Shot 2020-01-05 at 8 35 56 PM" src="https://user-images.githubusercontent.com/1192452/71795437-0414f300-2ffb-11ea-9ee7-0777cec64b53.png">
<img width="1115" alt="Screen Shot 2020-01-05 at 8 36 01 PM" src="https://user-images.githubusercontent.com/1192452/71795438-0414f300-2ffb-11ea-9b20-34651ec3d9ef.png">


## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
