### PR TITLE
Strict Mode friendly, examples, start of types

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,20 @@ class Example extends FASTElement {
   </script>
 </body>
 ```
+
+### Example of programmatically creating the element
+```html
+<head>
+  <script
+    type="module"
+    src="https://cdn.jsdelivr.net/npm/@pwabuilder/pwainstall"
+  ></script>
+</head>
+<body>
+  <script async defer>
+    var installComponent = document.createElement('pwa-install');
+    document.body.appendChild(installComponent);
+    installComponent.getInstalledStatus();
+  </script>
+</body>
+```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ live demo: https://pwainstall.glitch.me
 | `closePrompt()` | `Closes the install modal` |
 | `getInstalledStatus()` | `Tell if the PWA is installed or not` |
 
+Interactions with the methods requires a reference to the element itself, if using webcomponents or a library like Lit-Element or Fast-Element, this can be done easily within the  if using the component from the browser
 
 ## Styling
 
@@ -87,4 +88,89 @@ If you need to style this component more comprehensively, you can use [Shadow Pa
 pwa-install::part(openButton) {
   background: grey;
 }
+```
+
+## Advanced Examples
+
+#### Example with Component Reference (Web Components)
+```html
+<template id="example">
+  <style></style>
+  ...
+  <pwa-install></pwa-install>
+</template>
+```
+
+```javascript
+customElements.define('example',
+class Example extends HTMLElement {
+  constructor() {
+    super();
+    let template = document.getElementById("example");
+    let templateContent = template.content;
+    this.shadowRoot = this.attachShadow({mode: 'open'})
+      .appendChild(templateContent.cloneNode(true));
+    this.installComponent = document.getElementsByTagName("el-example")[0].shadowRoot.querySelector("pwa-install")
+  }
+})
+```
+
+#### Example with Component Reference (Lit-Element)
+
+```javascript
+// Using module import
+import { LitElement, html, property, query } from 'lit-element';
+import "@pwabuilder/pwainstall";
+
+class Example extends LitElement {
+  @query("installId") componentRef: HTMLElement
+
+  render() {
+    return html`
+      <body>
+        <pwa-install id="installId"></pwa-install>
+      </body>
+    `
+  }
+
+  interactionWithComponent() {
+    // See the methods section
+    this.componentRef.getInstalledStatus();
+  }
+}
+```
+
+#### Example with Component Reference (Fast-Element)
+
+```javascript
+const template = html`
+  <pwa-install ref('installComponent')></pwa-install>
+`
+
+@customElement({ ... })
+class Example extends FASTElement {
+  installComponent: HTMLElement & Interface;
+
+  interactionWithComponent() {
+    this.installComponent.getInstalledStatus();
+  }
+}
+
+```
+
+### Example of grabbing from the dom
+```html
+<head>
+  <script
+    type="module"
+    src="https://cdn.jsdelivr.net/npm/@pwabuilder/pwainstall"
+  ></script>
+</head>
+<body>
+  <pwa-install id="installComponent"></pwa-install>
+  <script async defer>
+    const ref = document.getElementById("installComponent);
+    red.getInstalledStatus();
+  </script>
+</body>
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ live demo: https://pwainstall.glitch.me
 
 | Property             | Attribute            | Description                                                                     | Type      | Default                                             |
 | -------------------- | -------------------- | ------------------------------------------------------------------------------- | --------- | --------------------------------------------------- |
+| `openmodal`          | `openmodal`          | Controls the opening of the modal via attribute, consider using the function    | `boolean` | `false`                                             |
 | `usecustom`          | `usecustom`          | Hides default button                                                            | `boolean` | `false`                                             |
 | `manifestpath`       | `manifestpath`       | path to your web manifest                                                       | `string`  | `manifest.json`                                     |
 | `explainer`          | `explainer`          | Controls the text of the explainer text just below the titlee of the app header | `string`  | `This app can be installed on`                      |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ live demo: https://pwainstall.glitch.me
 
 | Property             | Attribute            | Description                                                                     | Type      | Default                                             |
 | -------------------- | -------------------- | ------------------------------------------------------------------------------- | --------- | --------------------------------------------------- |
-| `showopen`           | `showopen`           | Will always show the install button                                             | `boolean` | `false`                                             |
 | `usecustom`          | `usecustom`          | Hides default button                                                            | `boolean` | `false`                                             |
 | `manifestpath`       | `manifestpath`       | path to your web manifest                                                       | `string`  | `manifest.json`                                     |
 | `explainer`          | `explainer`          | Controls the text of the explainer text just below the titlee of the app header | `string`  | `This app can be installed on`                      |

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -682,9 +682,9 @@ export class pwainstall extends LitElement {
   }
 
   scrollToLeft(): void {
-    const screenshotsDiv = this.shadowRoot.querySelector("#screenshots");
+    const screenshotsDiv = this.shadowRoot?.querySelector("#screenshots");
     // screenshotsDiv.scrollBy(-10, 0);
-    screenshotsDiv.scrollBy({
+    screenshotsDiv?.scrollBy({
       // left: -15,
       left: -screenshotsDiv.clientWidth,
       top: 0,
@@ -693,9 +693,9 @@ export class pwainstall extends LitElement {
   }
 
   scrollToRight(): void {
-    const screenshotsDiv = this.shadowRoot.querySelector("#screenshots");
+    const screenshotsDiv = this.shadowRoot?.querySelector("#screenshots");
     // screenshotsDiv.scrollBy(10, 0);
-    screenshotsDiv.scrollBy({
+    screenshotsDiv?.scrollBy({
       // left: 15,
       left: screenshotsDiv.clientWidth,
       top: 0,

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -804,7 +804,7 @@ export class pwainstall extends LitElement {
         : null}
       ${this.openmodal === true
         ? html`
-          <div id="installModalWrapper">
+          <dialog id="installModalWrapper">
           ${
             this.openmodal
               ? html`<div
@@ -929,7 +929,7 @@ export class pwainstall extends LitElement {
                 </button>`
           }
         </div>
-          </div>`
+        </dialog>`
             : html`<p id="iosText">${this.iosinstallinfotext}</p>`
         }
         `

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -23,7 +23,6 @@ export class pwainstall extends LitElement {
   };
 
   @property({ type: Boolean }) openmodal: boolean = false;
-  @property({ type: Boolean }) showopen: boolean = false;
   @property({ type: Boolean }) isSupportingBrowser: boolean;
   @property({ type: Boolean }) isIOS: boolean;
   @property({ type: Boolean }) installed: boolean;

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -12,16 +12,23 @@ interface ManifestData {
 @customElement("pwa-install")
 export class pwainstall extends LitElement {
   @property({ type: String }) manifestpath: string = "manifest.json";
-  @property({ type: String }) iconpath: string;
-  @property({ type: Object }) manifestdata: ManifestData;
+  @property({ type: String }) iconpath: string = "";
+  @property({ type: Object }) manifestdata: ManifestData = {
+    name: "",
+    short_name: "",
+    description: "",
+    icons: [],
+    screenshots: [],
+    features: []
+  };
 
   @property({ type: Boolean }) openmodal: boolean = false;
-  @property({ type: Boolean }) showopen: boolean;
+  @property({ type: Boolean }) showopen: boolean = false;
   @property({ type: Boolean }) isSupportingBrowser: boolean;
   @property({ type: Boolean }) isIOS: boolean;
   @property({ type: Boolean }) installed: boolean;
   @property({ type: Boolean }) hasprompt: boolean = false;
-  @property({ type: Boolean }) usecustom: boolean;
+  @property({ type: Boolean }) usecustom: boolean = false;
   @property({ type: Array }) relatedApps: any[] = [];
 
   @property({ type: String }) explainer: string =
@@ -597,7 +604,7 @@ export class pwainstall extends LitElement {
       navigator.userAgent.includes("iPhone") ||
       navigator.userAgent.includes("iPad") ||
       (navigator.userAgent.includes("Macintosh") &&
-        navigator.maxTouchPoints &&
+        typeof navigator.maxTouchPoints === "number" &&
         navigator.maxTouchPoints > 2);
 
     this.installed = false;
@@ -630,7 +637,7 @@ export class pwainstall extends LitElement {
     }
   }
 
-  handleInstallPromptEvent(event): void {
+  handleInstallPromptEvent(event: Event): void {
     this.deferredprompt = event;
 
     this.hasprompt = true;
@@ -640,7 +647,7 @@ export class pwainstall extends LitElement {
 
   // Check that the manifest has our 3 required properties
   // If not console an error to the user and return
-  checkManifest(manifestData): void {
+  checkManifest(manifestData: ManifestData): void {
     if (!manifestData.icons || !manifestData.icons[0]) {
       console.error("Your web manifest must have atleast one icon listed");
       return;
@@ -657,7 +664,7 @@ export class pwainstall extends LitElement {
     }
   }
 
-  async getManifestData(): Promise<ManifestData> {
+  async getManifestData(): Promise<ManifestData | null> {
     try {
       const response = await fetch(this.manifestpath);
       const data = await response.json();
@@ -670,8 +677,9 @@ export class pwainstall extends LitElement {
         return data;
       }
     } catch (err) {
-      return null;
     }
+
+    return null;
   }
 
   scrollToLeft(): void {
@@ -750,12 +758,10 @@ export class pwainstall extends LitElement {
 
         let event = new CustomEvent("hide");
         this.dispatchEvent(event);
-
-        return false;
       }
-    } else {
-      // handle else case
     }
+
+    return false;
   }
 
   public getInstalledStatus(): boolean {

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -728,6 +728,9 @@ export class pwainstall extends LitElement implements PWAInstall {
 
     let event = new CustomEvent("show");
     this.dispatchEvent(event);
+    this.updateComplete.then(() => {
+      (this.shadowRoot?.querySelector("#closeButton") as HTMLElement)?.focus()
+    });
   }
 
   public closePrompt(): void {
@@ -808,6 +811,10 @@ export class pwainstall extends LitElement implements PWAInstall {
 
       resolve();
     });
+  }
+
+  focusOut() {
+    console.log("focus out");
   }
 
   render() {

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -1,5 +1,25 @@
 import { LitElement, html, customElement, property, css } from "lit-element";
 
+export interface PWAInstallAttributes {
+  openmodal?: boolean;
+  usecustom?: boolean;
+  manifestpath?: string;
+  explainer?: string;
+  featuresheader?: string;
+  descriptionheader?: string;
+  installbuttontext?: string;
+  cancelbuttontext?: string;
+  iosinstallinfotext?: string;
+}
+
+export interface PWAInstallMethods {
+  openPrompt(): void
+  closePrompt(): void
+  getInstalledStatus(): boolean
+}
+
+export type PWAInstall = PWAInstallAttributes & PWAInstallMethods;
+
 interface ManifestData {
   name: string;
   short_name: string;
@@ -10,7 +30,7 @@ interface ManifestData {
 }
 
 @customElement("pwa-install")
-export class pwainstall extends LitElement {
+export class pwainstall extends LitElement implements PWAInstall {
   @property({ type: String }) manifestpath: string = "manifest.json";
   @property({ type: String }) iconpath: string = "";
   @property({ type: Object }) manifestdata: ManifestData = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "declaration": true,
     "esModuleInterop": true,
     "sourceMap": false,
-    "rootDir": "src"
+    "rootDir": "src",
+    "strict": true
   },
 
   "exclude": [


### PR DESCRIPTION
## TODO in follow up - the types actually do have an advantage I've discovered, before a semver I'd like to add the types to the component so that user's can use the interface. AKA when using strict mode, there's no easy way of using the methods with component references, hence the need, also if you programmatically create the component, the attributes would make it easier to generate the component.

Fixes #455 #457 #104 #5 

## PR Type

- Bugfix

## Describe the current behavior?

- Focus not shifting to the dialog properly.
- Not TS strict mode friendly.
- Strange type related issues where the value of some components are intersect types of (boolean | number) rather than the intended boolean.

## Describe the new behavior?

- Docs clearer, with examples for various ways of usage.
- Focus behavior is more consistent with dialog and focus moving after update to the component.

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
