### PR TITLE
pwa-install type declaration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ import "@pwabuilder/pwainstall"; // module import, allows for use in templates.
 class YourClass extends RenderLib {
   ...
 
-  get installComponent(): PWAInstall {
+  get installComponent(): PWAInstallComponent {
     return this.shadowRoot?.querySelector("pwa-install");
   }
 
@@ -175,7 +175,7 @@ const template = html`
 
 @customElement({ ... })
 class Example extends FASTElement {
-  @observable installComponent: PWAInstall | undefined;
+  @observable installComponent: PWAInstallComponent | undefined;
 
   @volatile
   get installComponent() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+/// <reference lib="dom"/>
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "pwa-install": PWAInstallComponent;
+  }
+
+  interface PWAInstallComponent extends HTMLElement {
+    openmodal?: boolean;
+    usecustom?: boolean;
+    manifestpath?: string;
+    explainer?: string;
+    featuresheader?: string;
+    descriptionheader?: string;
+    installbuttontext?: string;
+    cancelbuttontext?: string;
+    iosinstallinfotext?: string;
+
+    openPrompt(): void;
+    closePrompt(): void;
+    getInstalledStatus(): boolean;
+  }
+}
+
+export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pwabuilder/pwainstall",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@pwabuilder/pwainstall",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "",
   "main": "dist/pwa-install.js",
   "module": "dist/pwa-install.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "./node_modules/.bin/karma start --coverage",
     "test:watch": "karma start --auto-watch=true --single-run=false",

--- a/src/pwa-install.ts
+++ b/src/pwa-install.ts
@@ -1,25 +1,5 @@
 import { LitElement, html, customElement, property, css } from "lit-element";
 
-export interface PWAInstallAttributes {
-  openmodal?: boolean;
-  usecustom?: boolean;
-  manifestpath?: string;
-  explainer?: string;
-  featuresheader?: string;
-  descriptionheader?: string;
-  installbuttontext?: string;
-  cancelbuttontext?: string;
-  iosinstallinfotext?: string;
-}
-
-export interface PWAInstallMethods {
-  openPrompt(): void;
-  closePrompt(): void;
-  getInstalledStatus(): boolean;
-}
-
-export type PWAInstall = PWAInstallAttributes & PWAInstallMethods;
-
 interface ManifestData {
   name: string;
   short_name: string;
@@ -30,7 +10,7 @@ interface ManifestData {
 }
 
 @customElement("pwa-install")
-export class pwainstall extends LitElement implements PWAInstall {
+export class pwainstall extends LitElement implements PWAInstallComponent {
   @property({ type: String }) manifestpath: string = "manifest.json";
   @property({ type: String }) iconpath: string = "";
   @property({ type: Object }) manifestdata: ManifestData = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "node_modules"
   ],
   "include": [
-    "src"
+    "src", "index.d.ts"
   ]
 }


### PR DESCRIPTION
modifying the global interface with HTMLTagElementNameMap addition for really nice syntactic sugar

## PR Type

- Typescript Declaration File

## Describe the current behavior?

Typescript doesn't emit enough information to really make use of the component.

## Describe the new behavior?

Emits the interface when used with `document.createElement("pwa-install")`, `this.shadowRoot.querySelector("pwa-install")`

## PR Checklist

- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target master branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.


## Additional Information
