### PR TITLE
fix: add git repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,13 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-terser": "^7.0.0",
     "typescript": "^4.0.2"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pwa-builder/pwa-install.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pwa-builder/pwa-install/issues"
+  },
+  "homepage": "https://github.com/pwa-builder/pwa-install#readme"
 }


### PR DESCRIPTION
## PR Type

- Bugfix

## Describe the current behavior?

The Git repo information is missing from the npm package page: https://www.npmjs.com/package/@pwabuilder/pwainstall

## Describe the new behavior?

npm will display a link to GitHub once the new package is published.

## Additional Information

I ran `npm init --yes` to generate this information.
