### PR TITLE
fix(): typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ class Example extends FASTElement {
 <body>
   <pwa-install id="installComponent"></pwa-install>
   <script async defer>
-    const ref = document.getElementById("installComponent);
-    red.getInstalledStatus();
+    const ref = document.getElementById("installComponent");
+    ref.getInstalledStatus();
   </script>
 </body>
 ```


### PR DESCRIPTION
# Fix
Fixes a typo in README.md in [this example code](https://github.com/arpitdalal/pwa-install#example-of-grabbing-from-the-dom).

## Additional information
A double quote was missing after the `document.getElementById("installComponent`
`ref` variable was mistyped as `red`